### PR TITLE
Upgrade to dotnet 7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
 MAINTAINER Bengt Fredh <brf@digdir.no>
 
+COPY src/cert-generator ./cert-generator
+WORKDIR cert-generator/
 
-RUN git clone https://github.com/Altinn/cert-generator.git && cd cert-generator && \
-    dotnet build Generator.sln
+RUN dotnet build cert-generator.csproj -o /app_output
 
-FROM mcr.microsoft.com/dotnet/aspnet:3.1-alpine AS final
+FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS final
 MAINTAINER Bengt Fredh <brf@digdir.no>
 
-COPY --from=build cert-generator/src/cert-generator/bin/Debug/netcoreapp3.1/* /usr/local/bin/
+COPY --from=build /app_output /usr/local/bin/
 
 WORKDIR /data
 VOLUME /data

--- a/Generator.sln
+++ b/Generator.sln
@@ -1,12 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29503.13
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34202.233
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "cert-generator", "src\cert-generator\cert-generator.csproj", "{DF65DD2F-AFA2-4632-84A6-AA4CE040D9B2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8DEF4338-4465-45A3-A25C-26B933709F84}"
 	ProjectSection(SolutionItems) = preProject
+		Dockerfile = Dockerfile
+		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/cert-generator/cert-generator.csproj
+++ b/src/cert-generator/cert-generator.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <RootNamespace>CertGenerator</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
## Description
Upgrade project to dotnet v7.0

One major change in the Dockerfile is that the code is now assumed to be locally together with the docker file instead of pulling the code from github. This can be reverted if the docker file is used on its own.

The advantage of the change is that it now becomes possible to test changes locally. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
