### PR TITLE
ci-cd: Set ubuntu-runner ver 22.04 to prevent future breaking build

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     env:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       packages: write
     env:

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
As described in #26 , the ubuntu-runner for the dotnet-code build breaks when running on ubuntu image 24.04.
The change in this PR prevents failing ci-cd workflow when 24,04 starts being used in the "ubuntu-latest" label in GitHub Actions.

## Related Issue(s)
- #26 
- [PR#102](https://github.com/orgs/Altinn/projects/20/views/11?pane=issue&itemId=87224629&issue=Altinn%7Cteam-core-private%7C102) in team core private

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
